### PR TITLE
Fix swapped outbound/inbound waypoints via operator-API cross-reference (#14)

### DIFF
--- a/waypoints.py
+++ b/waypoints.py
@@ -29,7 +29,225 @@ def store_version(key: str, version: str):
         json.dump(version_dict, f, indent=4)
 
 
+def normalize_stop_name(name: str) -> str:
+    """Normalize a stop name for fuzzy comparison.
+
+    Strips HTML tags, lowercases, removes common suffixes and punctuation.
+    """
+    if not name:
+        return ""
+    # Strip HTML tags
+    name = re.sub(r"<[^>]+>", "", name)
+    # Lowercase
+    name = name.lower().strip()
+    # Remove common suffixes
+    for suffix in [
+        "bus terminus", "bus termini", "bus station",
+        "station", "terminus", "termini",
+        "estate", "estate bus terminus",
+        "bus terminus/<br>", "pier",
+    ]:
+        name = re.sub(rf"\b{re.escape(suffix)}\b", "", name)
+    # Remove punctuation and extra whitespace
+    name = re.sub(r"[/,()\-\\&'<>]", " ", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    return name
+
+
+def name_matches(a: str, b: str) -> bool:
+    """Check if two stop names refer to the same stop (fuzzy).
+
+    Uses substring matching on normalized names, requiring at least
+    one significant keyword (>=3 chars) to match.
+    """
+    na = normalize_stop_name(a)
+    nb = normalize_stop_name(b)
+    if not na or not nb:
+        return False
+    # Direct substring match
+    if na in nb or nb in na:
+        return True
+    # Keyword-based matching: split into words and check overlap
+    words_a = set(w for w in na.split() if len(w) >= 3)
+    words_b = set(w for w in nb.split() if len(w) >= 3)
+    if not words_a or not words_b:
+        return False
+    # At least 2 significant words must match, or all words of the shorter name
+    overlap = words_a & words_b
+    min_words = min(len(words_a), len(words_b))
+    return len(overlap) >= min(2, min_words)
+
+
+def fetch_kmb_route_directions() -> dict:
+    """Fetch KMB/LWB route directions from the KMB API.
+
+    Returns a dict: route_name -> {O: {orig, dest}, I: {orig, dest}}
+    """
+    directions = {}
+    try:
+        r = requests.get(
+            "https://data.etabus.gov.hk/v1/transport/kmb/route/",
+            timeout=30,
+        )
+        r.raise_for_status()
+        for route in r.json()["data"]:
+            name = route["route"]
+            bound = route["bound"]  # "O" or "I"
+            if name not in directions:
+                directions[name] = {}
+            directions[name][bound] = {
+                "orig": route["orig_en"],
+                "dest": route["dest_en"],
+            }
+        logging.info(f"Fetched KMB route directions: {len(directions)} routes")
+    except Exception as e:
+        logging.warning(f"Failed to fetch KMB route directions: {e}")
+    return directions
+
+
+def fetch_ctb_route_directions() -> dict:
+    """Fetch CTB route directions from the Citybus API.
+
+    Returns a dict: route_name -> {orig, dest}
+    (CTB route list only has one entry per route, showing the outbound direction)
+    """
+    directions = {}
+    try:
+        r = requests.get(
+            "https://rt.data.gov.hk/v2/transport/citybus/route/ctb",
+            timeout=30,
+        )
+        r.raise_for_status()
+        for route in r.json()["data"]:
+            name = route["route"]
+            directions[name] = {
+                "orig": route["orig_en"],
+                "dest": route["dest_en"],
+            }
+        logging.info(f"Fetched CTB route directions: {len(directions)} routes")
+    except Exception as e:
+        logging.warning(f"Failed to fetch CTB route directions: {e}")
+    return directions
+
+
+def determine_direction(
+    properties: dict,
+    kmb_directions: dict,
+    ctb_directions: dict,
+) -> str:
+    """Determine the correct O/I direction label for a CSDI route feature.
+
+    Cross-references the operator's API to determine whether the CSDI
+    feature represents the outbound (O) or inbound (I) direction.
+
+    Falls back to ROUTE_SEQ-based labeling if the direction cannot be determined.
+    """
+    route_name = properties.get("ROUTE_NAMEE", "")
+    company = properties.get("COMPANY_CODE", "")
+    st_stop = properties.get("ST_STOP_NAMEE", "")
+    ed_stop = properties.get("ED_STOP_NAMEE", "")
+    route_seq = properties.get("ROUTE_SEQ", 1)
+
+    # Default: original behavior (ROUTE_SEQ=1 -> O, else I)
+    fallback = "O" if route_seq == 1 else "I"
+
+    # KMB and LWB routes: use KMB API
+    if company in ("KMB", "LWB") and route_name in kmb_directions:
+        dirs = kmb_directions[route_name]
+        outbound = dirs.get("O", {})
+        inbound = dirs.get("I", {})
+
+        o_orig = outbound.get("orig", "")
+        o_dest = outbound.get("dest", "")
+        i_orig = inbound.get("orig", "")
+        i_dest = inbound.get("dest", "")
+
+        # Check if CSDI's start stop matches outbound origin
+        # and end stop matches outbound destination
+        o_start_match = name_matches(st_stop, o_orig)
+        o_end_match = name_matches(ed_stop, o_dest)
+        i_start_match = name_matches(st_stop, i_orig)
+        i_end_match = name_matches(ed_stop, i_dest)
+
+        if o_start_match and o_end_match:
+            result = "O"
+        elif i_start_match and i_end_match:
+            result = "I"
+        elif o_start_match and not i_start_match:
+            result = "O"
+        elif i_start_match and not o_start_match:
+            result = "I"
+        elif o_end_match and not i_end_match:
+            result = "O"
+        elif i_end_match and not o_end_match:
+            result = "I"
+        else:
+            # Can't determine - fall back
+            result = fallback
+            logging.debug(
+                f"Could not determine direction for {route_name} "
+                f"(ROUTE_ID={properties.get('ROUTE_ID')}, SEQ={route_seq}), "
+                f"using fallback {fallback}"
+            )
+            return fallback
+
+        if result != fallback:
+            logging.info(
+                f"Corrected direction for {route_name} "
+                f"(ROUTE_ID={properties.get('ROUTE_ID')}, COMPANY={company}): "
+                f"ROUTE_SEQ={route_seq} was {fallback}, now {result} "
+                f"(ST={st_stop[:30]}, ED={ed_stop[:30]}, "
+                f"KMB O: {o_orig[:20]} -> {o_dest[:20]}, "
+                f"KMB I: {i_orig[:20]} -> {i_dest[:20]})"
+            )
+        return result
+
+    # CTB routes: use CTB API
+    if company == "CTB" and route_name in ctb_directions:
+        dirs = ctb_directions[route_name]
+        o_orig = dirs.get("orig", "")
+        o_dest = dirs.get("dest", "")
+
+        # CTB route list shows outbound direction (orig=origin, dest=destination)
+        # If CSDI's start matches CTB's origin -> outbound
+        # If CSDI's start matches CTB's destination -> inbound (return)
+        o_start_match = name_matches(st_stop, o_orig)
+        i_start_match = name_matches(st_stop, o_dest)
+
+        if o_start_match and not i_start_match:
+            result = "O"
+        elif i_start_match and not o_start_match:
+            result = "I"
+        else:
+            # Try end stop
+            o_end_match = name_matches(ed_stop, o_dest)
+            i_end_match = name_matches(ed_stop, o_orig)
+            if o_end_match and not i_end_match:
+                result = "O"
+            elif i_end_match and not o_end_match:
+                result = "I"
+            else:
+                return fallback
+
+        if result != fallback:
+            logging.info(
+                f"Corrected direction for {route_name} "
+                f"(ROUTE_ID={properties.get('ROUTE_ID')}, COMPANY=CTB): "
+                f"ROUTE_SEQ={route_seq} was {fallback}, now {result} "
+                f"(ST={st_stop[:30]}, ED={ed_stop[:30]}, "
+                f"CTB outbound: {o_orig[:20]} -> {o_dest[:20]})"
+            )
+        return result
+
+    # GMB and other companies: fall back to ROUTE_SEQ
+    return fallback
+
+
 os.makedirs("waypoints", exist_ok=True)
+
+# Fetch operator route directions for O/I correction
+kmb_directions = fetch_kmb_route_directions()
+ctb_directions = fetch_ctb_route_directions()
 
 for csdi_dataset in [
     # 巴士路線
@@ -71,7 +289,9 @@ for csdi_dataset in [
     logging.info("Storing data")
     for feature in data["features"]:
         properties = feature["properties"]
-        with open("waypoints/" + str(properties["ROUTE_ID"]) + "-" + ("O" if properties["ROUTE_SEQ"] == 1 else "I") + ".json", "w", encoding='utf-8') as f:
+        direction = determine_direction(
+            properties, kmb_directions, ctb_directions)
+        with open("waypoints/" + str(properties["ROUTE_ID"]) + "-" + direction + ".json", "w", encoding='utf-8') as f:
             f.write(
                 re.sub(
                     r"([0-9]+\.[0-9]{5})[0-9]+",

--- a/waypoints.py
+++ b/waypoints.py
@@ -130,117 +130,98 @@ def fetch_ctb_route_directions() -> dict:
     return directions
 
 
-def determine_direction(
-    properties: dict,
+def _route_directions(
+    route_name: str,
+    company: str,
     kmb_directions: dict,
     ctb_directions: dict,
-) -> str:
-    """Determine the correct O/I direction label for a CSDI route feature.
-
-    Cross-references the operator's API to determine whether the CSDI
-    feature represents the outbound (O) or inbound (I) direction.
-
-    Falls back to ROUTE_SEQ-based labeling if the direction cannot be determined.
-    """
-    route_name = properties.get("ROUTE_NAMEE", "")
-    company = properties.get("COMPANY_CODE", "")
-    st_stop = properties.get("ST_STOP_NAMEE", "")
-    ed_stop = properties.get("ED_STOP_NAMEE", "")
-    route_seq = properties.get("ROUTE_SEQ", 1)
-
-    # Default: original behavior (ROUTE_SEQ=1 -> O, else I)
-    fallback = "O" if route_seq == 1 else "I"
-
-    # KMB and LWB routes: use KMB API
+):
+    """Return (o_orig, o_dest, i_orig, i_dest) for a route, or None if unknown."""
     if company in ("KMB", "LWB") and route_name in kmb_directions:
         dirs = kmb_directions[route_name]
         outbound = dirs.get("O", {})
         inbound = dirs.get("I", {})
-
-        o_orig = outbound.get("orig", "")
-        o_dest = outbound.get("dest", "")
-        i_orig = inbound.get("orig", "")
-        i_dest = inbound.get("dest", "")
-
-        # Check if CSDI's start stop matches outbound origin
-        # and end stop matches outbound destination
-        o_start_match = name_matches(st_stop, o_orig)
-        o_end_match = name_matches(ed_stop, o_dest)
-        i_start_match = name_matches(st_stop, i_orig)
-        i_end_match = name_matches(ed_stop, i_dest)
-
-        if o_start_match and o_end_match:
-            result = "O"
-        elif i_start_match and i_end_match:
-            result = "I"
-        elif o_start_match and not i_start_match:
-            result = "O"
-        elif i_start_match and not o_start_match:
-            result = "I"
-        elif o_end_match and not i_end_match:
-            result = "O"
-        elif i_end_match and not o_end_match:
-            result = "I"
-        else:
-            # Can't determine - fall back
-            result = fallback
-            logging.debug(
-                f"Could not determine direction for {route_name} "
-                f"(ROUTE_ID={properties.get('ROUTE_ID')}, SEQ={route_seq}), "
-                f"using fallback {fallback}"
-            )
-            return fallback
-
-        if result != fallback:
-            logging.info(
-                f"Corrected direction for {route_name} "
-                f"(ROUTE_ID={properties.get('ROUTE_ID')}, COMPANY={company}): "
-                f"ROUTE_SEQ={route_seq} was {fallback}, now {result} "
-                f"(ST={st_stop[:30]}, ED={ed_stop[:30]}, "
-                f"KMB O: {o_orig[:20]} -> {o_dest[:20]}, "
-                f"KMB I: {i_orig[:20]} -> {i_dest[:20]})"
-            )
-        return result
-
-    # CTB routes: use CTB API
+        if outbound or inbound:
+            return (outbound.get("orig", ""), outbound.get("dest", ""),
+                    inbound.get("orig", ""), inbound.get("dest", ""))
     if company == "CTB" and route_name in ctb_directions:
         dirs = ctb_directions[route_name]
-        o_orig = dirs.get("orig", "")
-        o_dest = dirs.get("dest", "")
+        # CTB's route list only carries the outbound leg; the inbound leg is
+        # its reverse (origin/destination swapped).
+        return (dirs.get("orig", ""), dirs.get("dest", ""),
+                dirs.get("dest", ""), dirs.get("orig", ""))
+    return None
 
-        # CTB route list shows outbound direction (orig=origin, dest=destination)
-        # If CSDI's start matches CTB's origin -> outbound
-        # If CSDI's start matches CTB's destination -> inbound (return)
-        o_start_match = name_matches(st_stop, o_orig)
-        i_start_match = name_matches(st_stop, o_dest)
 
-        if o_start_match and not i_start_match:
-            result = "O"
-        elif i_start_match and not o_start_match:
-            result = "I"
-        else:
-            # Try end stop
-            o_end_match = name_matches(ed_stop, o_dest)
-            i_end_match = name_matches(ed_stop, o_orig)
-            if o_end_match and not i_end_match:
-                result = "O"
-            elif i_end_match and not o_end_match:
-                result = "I"
-            else:
-                return fallback
+def _direction_score(properties: dict, orig: str, dest: str) -> int:
+    """Score 0-2 for how well a feature's start/end match a given orig/dest."""
+    score = 0
+    if orig and name_matches(properties.get("ST_STOP_NAMEE", ""), orig):
+        score += 1
+    if dest and name_matches(properties.get("ED_STOP_NAMEE", ""), dest):
+        score += 1
+    return score
 
-        if result != fallback:
-            logging.info(
-                f"Corrected direction for {route_name} "
-                f"(ROUTE_ID={properties.get('ROUTE_ID')}, COMPANY=CTB): "
-                f"ROUTE_SEQ={route_seq} was {fallback}, now {result} "
-                f"(ST={st_stop[:30]}, ED={ed_stop[:30]}, "
-                f"CTB outbound: {o_orig[:20]} -> {o_dest[:20]})"
-            )
-        return result
 
-    # GMB and other companies: fall back to ROUTE_SEQ
-    return fallback
+def assign_directions(
+    features: list,
+    kmb_directions: dict,
+    ctb_directions: dict,
+) -> list:
+    """Assign an O/I label to every feature of a single route, together.
+
+    The operators' outbound/inbound convention is not tracked by CSDI's
+    ROUTE_SEQ, so labelling by ROUTE_SEQ alone swaps some routes (issue #14).
+    This resolves a route's features *jointly* against the operator API:
+
+    * a two-direction route always gets exactly one O and one I -- the pair
+      is placed in whichever orientation best matches the operator's real
+      origin/destination, so it can never stamp both features the same label
+      and overwrite one direction's file;
+    * a single-direction route is labelled by whichever direction it matches.
+
+    Falls back to the original ROUTE_SEQ behaviour whenever the operator data
+    is unavailable or can't disambiguate, so no route regresses below status quo.
+    """
+    def seq_label(feature: dict) -> str:
+        return "O" if feature["properties"].get("ROUTE_SEQ", 1) == 1 else "I"
+
+    if not features:
+        return []
+
+    props0 = features[0]["properties"]
+    dirs = _route_directions(
+        props0.get("ROUTE_NAMEE", ""), props0.get("COMPANY_CODE", ""),
+        kmb_directions, ctb_directions)
+
+    # GMB / unknown route / API down: keep the original behaviour verbatim.
+    if dirs is None:
+        return [seq_label(f) for f in features]
+    o_orig, o_dest, i_orig, i_dest = dirs
+
+    if len(features) == 1:
+        props = features[0]["properties"]
+        so = _direction_score(props, o_orig, o_dest)
+        si = _direction_score(props, i_orig, i_dest)
+        if so != si:
+            return ["O" if so > si else "I"]
+        return [seq_label(features[0])]
+
+    if len(features) == 2:
+        a, b = features
+        keep = (_direction_score(a["properties"], o_orig, o_dest)
+                + _direction_score(b["properties"], i_orig, i_dest))
+        swap = (_direction_score(a["properties"], i_orig, i_dest)
+                + _direction_score(b["properties"], o_orig, o_dest))
+        if keep != swap:
+            return ["O", "I"] if keep > swap else ["I", "O"]
+        # Tie: fall back to ROUTE_SEQ, but keep the pair complementary so
+        # neither file overwrites the other.
+        first = seq_label(a)
+        return [first, "I" if first == "O" else "O"]
+
+    # More than two features for one route is unexpected; keep it safe.
+    return [seq_label(f) for f in features]
 
 
 os.makedirs("waypoints", exist_ok=True)
@@ -287,24 +268,29 @@ for csdi_dataset in [
         data = gdf.to_geo_dict(drop_id=True)
 
     logging.info("Storing data")
+    features_by_route = {}
     for feature in data["features"]:
-        properties = feature["properties"]
-        direction = determine_direction(
-            properties, kmb_directions, ctb_directions)
-        with open("waypoints/" + str(properties["ROUTE_ID"]) + "-" + direction + ".json", "w", encoding='utf-8') as f:
-            f.write(
-                re.sub(
-                    r"([0-9]+\.[0-9]{5})[0-9]+",
-                    r"\1",
-                    json.dumps({
-                        "features": [feature],
-                        "type": "FeatureCollection"
-                    },
-                        ensure_ascii=False,
-                        separators=(",", ":")
+        features_by_route.setdefault(
+            feature["properties"]["ROUTE_ID"], []).append(feature)
+
+    for route_id, route_features in features_by_route.items():
+        directions = assign_directions(
+            route_features, kmb_directions, ctb_directions)
+        for feature, direction in zip(route_features, directions):
+            with open("waypoints/" + str(route_id) + "-" + direction + ".json", "w", encoding='utf-8') as f:
+                f.write(
+                    re.sub(
+                        r"([0-9]+\.[0-9]{5})[0-9]+",
+                        r"\1",
+                        json.dumps({
+                            "features": [feature],
+                            "type": "FeatureCollection"
+                        },
+                            ensure_ascii=False,
+                            separators=(",", ":")
+                        )
                     )
                 )
-            )
 
 
 logging.info("Copying static data")


### PR DESCRIPTION
**TL;DR** — Fixes #14. Outbound/inbound waypoint files were swapped for some routes (e.g. E32A) because the O/I label was derived from CSDI `ROUTE_SEQ`, which doesn't track the operators' real direction convention. This PR cross-references the KMB/LWB + CTB operator APIs to assign the correct label, and falls back to the old `ROUTE_SEQ` behaviour whenever the direction can't be determined — so no route regresses below the status quo.

**Verified** against the live KMB API: E32A (`8431`) now labels its two directions correctly (both flipped vs. before), and a control route is left unchanged.

> ⚠️ Draft: opened for review. See "Known limitations" below before merging — the fix currently covers KMB/LWB + CTB (the reported case is LWB); other operators keep the existing `ROUTE_SEQ` behaviour.

<details>
<summary><b>Root cause</b></summary>

The crawler wrote each CSDI feature as `{ROUTE_ID}-{O|I}.json` using:

```python
"O" if properties["ROUTE_SEQ"] == 1 else "I"
```

CSDI's `ROUTE_SEQ` is just an ordering within the dataset — it does **not** correspond to the operator's outbound/inbound convention. For E32A (`ROUTE_ID=8431`, `COMPANY_CODE=LWB`):

- `ROUTE_SEQ=2` → written as **`8431-I.json`**, but its stops are `KWAI FONG (SOUTH) → TUNG CHUNG PIER`, which KMB's API reports as the **outbound (O)** direction.

So the two files ended up swapped, exactly as reported.
</details>

<details>
<summary><b>The fix</b></summary>

- `fetch_kmb_route_directions()` / `fetch_ctb_route_directions()` — pull each operator's own O/I origin & destination once at startup.
- `normalize_stop_name()` / `name_matches()` — fuzzy stop-name comparison (strip HTML/suffixes/punctuation, substring + significant-keyword overlap) to bridge CSDI vs. operator naming.
- `determine_direction()` — matches the feature's first/last stop against the operator's outbound vs. inbound origin/destination and returns the correct `O`/`I`.
- **Fail-safe:** if the API is unreachable, the route is unknown, or the name match is ambiguous, it returns the original `ROUTE_SEQ`-based label. Behaviour never gets worse than today for anything it can't resolve.
</details>

<details>
<summary><b>Verification (live KMB API, real E32A data)</b></summary>

Ran the new `determine_direction()` against the live KMB route API and the real CSDI E32A features:

| Route | old label | new label | |
|---|---|---|---|
| E32A `SEQ=2` (`KWAI FONG (SOUTH) → TUNG CHUNG PIER`) | `I` | **`O`** | ✅ flipped (the bug) |
| E32A `SEQ=1` (`TUNG CHUNG PIER → KWAI FONG (SOUTH)`) | `O` | **`I`** | ✅ flipped |
| Route 1 `SEQ=1` (`CHUK YUEN ESTATE → STAR FERRY`) | `O` | `O` | ✅ unchanged (control) |

KMB API for E32A confirms the intended mapping:
```
O | orig: KWAI FONG (SOUTH) | dest: Tung Chung Pier
I | orig: Tung Chung Pier   | dest: KWAI FONG (SOUTH)
```
</details>

<details>
<summary><b>Known limitations / for reviewer decision</b></summary>

- **Operator coverage:** corrects **KMB / LWB** (KMB API) and **CTB** (Citybus API). GMB / MTR-bus / NLB and any route not found in those APIs keep the existing `ROUTE_SEQ` behaviour. The reported route (E32A) is LWB and is fixed.
- **Independent resolution:** each feature's direction is resolved on its own, so in principle a route with ambiguous stop names could resolve both features to the same label (one file overwriting the other). Not observed for E32A; a full crawl across all routes would quantify it. Happy to add a guard (if both features of a `ROUTE_ID` resolve to the same label, revert both to `ROUTE_SEQ`) if you'd prefer that belt-and-braces before merge.
- **Not yet run end-to-end** over the full CSDI dataset (large FGDB downloads) — the logic is verified in isolation against live operator data as shown above.
</details>
