### PR TITLE
Resolve O/I direction from routeFareList instead of CSDI ROUTE_SEQ

### DIFF
--- a/waypoints.py
+++ b/waypoints.py
@@ -75,10 +75,12 @@ def fetch_direction_index():
 def _resolve(feature, direction_index):
     """O/I for one feature by the direction whose first stop is nearest its line
     start, or None if unavailable / farther than the guard distance."""
-    coords = feature["geometry"]["coordinates"]
-    while isinstance(coords[0][0], list):  # MultiLineString -> first line
+    coords = (feature.get("geometry") or {}).get("coordinates") or []
+    while coords and isinstance(coords[0][0], list):  # MultiLineString -> line
         coords = coords[0]
-    lon, lat = coords[0]
+    if not coords:
+        return None
+    lon, lat = coords[0][0], coords[0][1]  # coords may be 3D (lon, lat, z)
     p = feature["properties"]
     cos = [_CO_ALIAS.get(c, c.lower())
            for c in str(p.get("COMPANY_CODE", "")).split("+")]

--- a/waypoints.py
+++ b/waypoints.py
@@ -75,12 +75,15 @@ def fetch_direction_index():
 def _resolve(feature, direction_index):
     """O/I for one feature by the direction whose first stop is nearest its line
     start, or None if unavailable / farther than the guard distance."""
+    # geopandas yields coords as (possibly nested) tuples, 2D or 3D; descend to
+    # the first point [lon, lat, ...] of the first line
     coords = (feature.get("geometry") or {}).get("coordinates") or []
-    while coords and isinstance(coords[0][0], list):  # MultiLineString -> line
+    while (coords and isinstance(coords[0], (list, tuple))
+           and isinstance(coords[0][0], (list, tuple))):
         coords = coords[0]
-    if not coords:
+    if not coords or not isinstance(coords[0], (list, tuple)):
         return None
-    lon, lat = coords[0][0], coords[0][1]  # coords may be 3D (lon, lat, z)
+    lon, lat = coords[0][0], coords[0][1]
     p = feature["properties"]
     cos = [_CO_ALIAS.get(c, c.lower())
            for c in str(p.get("COMPANY_CODE", "")).split("+")]

--- a/waypoints.py
+++ b/waypoints.py
@@ -100,7 +100,7 @@ def fetch_direction_index():
                         (bound, loc["lat"], loc["lng"]))
         logging.info(
             f"Fetched direction index for {
-                len(index)} (route, co) pairs")
+                len(index)}(route, co) pairs")
     except Exception as e:
         logging.warning(
             f"routeFareList fetch failed; O/I falls back to ROUTE_SEQ: {e}")

--- a/waypoints.py
+++ b/waypoints.py
@@ -95,12 +95,15 @@ def fetch_direction_index():
                 stops_co = v.get("stops", {}).get(co)
                 loc = stop_list.get(stops_co[0], {}).get(
                     "location") if stops_co else None
-                if bound and loc:
+                # only plain O/I; skip circular "OI"/"IO", tram "DT"/"UT",
+                # cross-boundary "LMC-*"/"TKS-*" -> those fall back to
+                # ROUTE_SEQ
+                if bound in ("O", "I") and loc:
                     index[(gtfs_id, co)].append(
                         (bound, loc["lat"], loc["lng"]))
         logging.info(
             f"Fetched direction index for {
-                len(index)}(route, co) pairs")
+                len(index)} (route, co) pairs")
     except Exception as e:
         logging.warning(
             f"routeFareList fetch failed; O/I falls back to ROUTE_SEQ: {e}")

--- a/waypoints.py
+++ b/waypoints.py
@@ -103,7 +103,7 @@ def fetch_direction_index():
                         (bound, loc["lat"], loc["lng"]))
         logging.info(
             f"Fetched direction index for {
-                len(index)} (route, co) pairs")
+                len(index)}(route, co) pairs")
     except Exception as e:
         logging.warning(
             f"routeFareList fetch failed; O/I falls back to ROUTE_SEQ: {e}")

--- a/waypoints.py
+++ b/waypoints.py
@@ -29,7 +29,122 @@ def store_version(key: str, version: str):
         json.dump(version_dict, f, indent=4)
 
 
+# --- O/I direction resolution -------------------------------------------
+# CSDI writes ROUTE_SEQ (1/2), which does NOT track the operators' outbound (O) /
+# inbound (I) convention, so labelling by ROUTE_SEQ swaps some routes (issue #14).
+# We resolve direction from hkbus's own routeFareList (the operators' O/I with
+# terminus names, per direction) and match it to each CSDI feature's start/end.
+
+# CSDI COMPANY_CODE -> hkbus routeFareList "co"
+_CO_ALIAS = {
+    "LWB": "kmb",
+    "KMB": "kmb",
+    "CTB": "ctb",
+    "NLB": "nlb",
+    "GMB": "gmb"}
+
+
+def normalize_stop_name(name):
+    """Lowercase, strip HTML/terminus suffixes/punctuation for fuzzy comparison.
+
+    CSDI and operator datasets name the same terminus differently
+    (e.g. "TUNG CHUNG DEVELOPMENT PIER" vs "Tung Chung Pier"), so an exact
+    match is not possible for a large share of routes.
+    """
+    if not name:
+        return ""
+    name = re.sub(r"<[^>]+>", "", name).lower().strip()
+    for suffix in ["bus terminus", "bus termini", "bus station", "station",
+                   "terminus", "termini", "estate", "pier", "development"]:
+        name = re.sub(rf"\b{re.escape(suffix)}\b", "", name)
+    name = re.sub(r"[/,()\-\\&'<>]", " ", name)
+    return re.sub(r"\s+", " ", name).strip()
+
+
+def name_matches(a, b):
+    na, nb = normalize_stop_name(a), normalize_stop_name(b)
+    if not na or not nb:
+        return False
+    if na in nb or nb in na:
+        return True
+    wa = {w for w in na.split() if len(w) >= 3}
+    wb = {w for w in nb.split() if len(w) >= 3}
+    return bool(wa and wb) and len(wa & wb) >= min(2, len(wa), len(wb))
+
+
+def fetch_route_directions():
+    """(co, route) -> {"O": (orig, dest), "I": (orig, dest)} from routeFareList."""
+    directions = {}
+    try:
+        route_list = requests.get(
+            "https://data.hkbus.app/routeFareList.json", timeout=60
+        ).json()["routeList"]
+        for v in route_list.values():
+            for co in v.get("co", []):
+                bound = v.get("bound", {}).get(co)
+                if bound:
+                    directions.setdefault((co, v["route"]), {})[bound] = (
+                        v["orig"]["en"], v["dest"]["en"])
+        logging.info(
+            f"Fetched directions for {
+                len(directions)} (co, route) pairs")
+    except Exception as e:
+        logging.warning(
+            f"routeFareList fetch failed; using ROUTE_SEQ fallback: {e}")
+    return directions
+
+
+def _score(props, orig, dest):
+    return ((1 if orig and name_matches(props.get("ST_STOP_NAMEE", ""), orig) else 0) +
+            (1 if dest and name_matches(props.get("ED_STOP_NAMEE", ""), dest) else 0))
+
+
+def assign_directions(features, route_directions):
+    """Assign O/I to every feature of one route, together.
+
+    Resolving a route's features jointly guarantees a two-direction route gets
+    exactly one O and one I (no file overwrites another), placed in whichever
+    orientation best matches the operators' origin/destination. Falls back to
+    ROUTE_SEQ when routeFareList has no usable entry or can't disambiguate.
+    """
+    def seq_label(f):
+        return "O" if f["properties"].get("ROUTE_SEQ", 1) == 1 else "I"
+
+    if not features:
+        return []
+    p0 = features[0]["properties"]
+    co = _CO_ALIAS.get(
+        p0.get(
+            "COMPANY_CODE", ""), p0.get(
+            "COMPANY_CODE", "").lower())
+    d = route_directions.get((co, p0.get("ROUTE_NAMEE", "")))
+    if not d:
+        return [seq_label(f) for f in features]
+    o_orig, o_dest = d.get("O", (None, None))
+    i_orig, i_dest = d.get("I", (None, None))
+
+    if len(features) == 1:
+        so = _score(features[0]["properties"], o_orig, o_dest)
+        si = _score(features[0]["properties"], i_orig, i_dest)
+        return [
+            seq_label(
+                features[0])] if so == si else (
+            ["O"] if so > si else ["I"])
+
+    if len(features) == 2:
+        a, b = (f["properties"] for f in features)
+        keep = _score(a, o_orig, o_dest) + _score(b, i_orig, i_dest)
+        swap = _score(a, i_orig, i_dest) + _score(b, o_orig, o_dest)
+        if keep != swap:
+            return ["O", "I"] if keep > swap else ["I", "O"]
+        first = seq_label(features[0])
+        return [first, "I" if first == "O" else "O"]
+
+    return [seq_label(f) for f in features]
+
+
 os.makedirs("waypoints", exist_ok=True)
+route_directions = fetch_route_directions()
 
 for csdi_dataset in [
     # 巴士路線
@@ -69,22 +184,28 @@ for csdi_dataset in [
         data = gdf.to_geo_dict(drop_id=True)
 
     logging.info("Storing data")
+    features_by_route = {}
     for feature in data["features"]:
-        properties = feature["properties"]
-        with open("waypoints/" + str(properties["ROUTE_ID"]) + "-" + ("O" if properties["ROUTE_SEQ"] == 1 else "I") + ".json", "w", encoding='utf-8') as f:
-            f.write(
-                re.sub(
-                    r"([0-9]+\.[0-9]{5})[0-9]+",
-                    r"\1",
-                    json.dumps({
-                        "features": [feature],
-                        "type": "FeatureCollection"
-                    },
-                        ensure_ascii=False,
-                        separators=(",", ":")
+        features_by_route.setdefault(
+            feature["properties"]["ROUTE_ID"], []).append(feature)
+
+    for route_id, route_features in features_by_route.items():
+        directions = assign_directions(route_features, route_directions)
+        for feature, direction in zip(route_features, directions):
+            with open("waypoints/" + str(route_id) + "-" + direction + ".json", "w", encoding='utf-8') as f:
+                f.write(
+                    re.sub(
+                        r"([0-9]+\.[0-9]{5})[0-9]+",
+                        r"\1",
+                        json.dumps({
+                            "features": [feature],
+                            "type": "FeatureCollection"
+                        },
+                            ensure_ascii=False,
+                            separators=(",", ":")
+                        )
                     )
                 )
-            )
 
 
 logging.info("Copying static data")

--- a/waypoints.py
+++ b/waypoints.py
@@ -87,7 +87,7 @@ def fetch_route_directions():
                         v["orig"]["en"], v["dest"]["en"])
         logging.info(
             f"Fetched directions for {
-                len(directions)} (co, route) pairs")
+                len(directions)}(co, route) pairs")
     except Exception as e:
         logging.warning(
             f"routeFareList fetch failed; using ROUTE_SEQ fallback: {e}")

--- a/waypoints.py
+++ b/waypoints.py
@@ -4,11 +4,14 @@ import requests
 import json
 import re
 import os
+import csv
+import math
 import zipfile
 import io
 import glob
 import shutil
 import geopandas
+from collections import defaultdict
 from tempfile import TemporaryDirectory
 import logging
 
@@ -29,122 +32,140 @@ def store_version(key: str, version: str):
         json.dump(version_dict, f, indent=4)
 
 
-# --- O/I direction resolution -------------------------------------------
-# CSDI writes ROUTE_SEQ (1/2), which does NOT track the operators' outbound (O) /
-# inbound (I) convention, so labelling by ROUTE_SEQ swaps some routes (issue #14).
-# We resolve direction from hkbus's own routeFareList (the operators' O/I with
-# terminus names, per direction) and match it to each CSDI feature's start/end.
+# --- Outbound (O) / inbound (I) direction resolution --------------------
+# CSDI writes ROUTE_SEQ (1/2), which does NOT track the operators' outbound/inbound
+# convention, so labelling by ROUTE_SEQ swaps some routes' -O/-I files (issue #14).
+# Resolve direction by IDs instead of terminal names (names vary too much between
+# datasets to match reliably):
+#   * CSDI ST_STOP_ID == GTFS stop_id (same registry) -> the feature's start coord
+#   * hkbus routeFareList gtfsId == CSDI ROUTE_ID (same registry) -> that route's
+#     directions, each with its bound (O/I) and first stop
+# GTFS stop-ids and hkbus's operator stop-ids are different registries with no shared
+# key, so the O-vs-I pick is by nearest start-stop *coordinate* (metres,
+# not names).
 
-# CSDI COMPANY_CODE -> hkbus routeFareList "co"
+GTFS_STOPS_URL = "https://static.data.gov.hk/td/pt-headway-en/gtfs.zip"
+ROUTE_FARE_LIST_URL = "https://data.hkbus.app/routeFareList.json"
 _CO_ALIAS = {
     "LWB": "kmb",
     "KMB": "kmb",
     "CTB": "ctb",
     "NLB": "nlb",
     "GMB": "gmb"}
+_MAX_MATCH_M = 500  # a start stop farther than this is treated as unresolved
 
 
-def normalize_stop_name(name):
-    """Lowercase, strip HTML/terminus suffixes/punctuation for fuzzy comparison.
-
-    CSDI and operator datasets name the same terminus differently
-    (e.g. "TUNG CHUNG DEVELOPMENT PIER" vs "Tung Chung Pier"), so an exact
-    match is not possible for a large share of routes.
-    """
-    if not name:
-        return ""
-    name = re.sub(r"<[^>]+>", "", name).lower().strip()
-    for suffix in ["bus terminus", "bus termini", "bus station", "station",
-                   "terminus", "termini", "estate", "pier", "development"]:
-        name = re.sub(rf"\b{re.escape(suffix)}\b", "", name)
-    name = re.sub(r"[/,()\-\\&'<>]", " ", name)
-    return re.sub(r"\s+", " ", name).strip()
+def _haversine(lat1, lon1, lat2, lon2):
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dphi, dlmb = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + \
+        math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+    return 2 * 6371000 * math.asin(math.sqrt(a))
 
 
-def name_matches(a, b):
-    na, nb = normalize_stop_name(a), normalize_stop_name(b)
-    if not na or not nb:
-        return False
-    if na in nb or nb in na:
-        return True
-    wa = {w for w in na.split() if len(w) >= 3}
-    wb = {w for w in nb.split() if len(w) >= 3}
-    return bool(wa and wb) and len(wa & wb) >= min(2, len(wa), len(wb))
-
-
-def fetch_route_directions():
-    """(co, route) -> {"O": (orig, dest), "I": (orig, dest)} from routeFareList."""
-    directions = {}
+def fetch_gtfs_stops():
+    """GTFS stop_id -> (lat, lon). CSDI ST_STOP_ID values are GTFS stop_ids."""
+    stops = {}
     try:
-        route_list = requests.get(
-            "https://data.hkbus.app/routeFareList.json", timeout=60
-        ).json()["routeList"]
-        for v in route_list.values():
-            for co in v.get("co", []):
-                bound = v.get("bound", {}).get(co)
-                if bound:
-                    directions.setdefault((co, v["route"]), {})[bound] = (
-                        v["orig"]["en"], v["dest"]["en"])
-        logging.info(
-            f"Fetched directions for {
-                len(directions)}(co, route) pairs")
+        z = zipfile.ZipFile(io.BytesIO(
+            requests.get(GTFS_STOPS_URL, timeout=120).content))
+        with z.open("stops.txt") as f:
+            for row in csv.DictReader(io.TextIOWrapper(f, "utf-8-sig")):
+                stops[row["stop_id"]] = (
+                    float(row["stop_lat"]), float(row["stop_lon"]))
+        logging.info(f"Fetched {len(stops)} GTFS stops")
     except Exception as e:
         logging.warning(
-            f"routeFareList fetch failed; using ROUTE_SEQ fallback: {e}")
-    return directions
+            f"GTFS stops fetch failed; O/I falls back to ROUTE_SEQ: {e}")
+    return stops
 
 
-def _score(props, orig, dest):
-    return ((1 if orig and name_matches(props.get("ST_STOP_NAMEE", ""), orig) else 0) +
-            (1 if dest and name_matches(props.get("ED_STOP_NAMEE", ""), dest) else 0))
+def fetch_direction_index():
+    """(ROUTE_ID, co) -> [(bound, lat, lng)] of each direction's first stop."""
+    index = defaultdict(list)
+    try:
+        rfl = requests.get(ROUTE_FARE_LIST_URL, timeout=120).json()
+        stop_list = rfl["stopList"]
+        for v in rfl["routeList"].values():
+            gtfs_id = v.get("gtfsId")
+            if not gtfs_id:
+                continue
+            for co in v.get("co", []):
+                bound = v.get("bound", {}).get(co)
+                stops_co = v.get("stops", {}).get(co)
+                loc = stop_list.get(stops_co[0], {}).get(
+                    "location") if stops_co else None
+                if bound and loc:
+                    index[(gtfs_id, co)].append(
+                        (bound, loc["lat"], loc["lng"]))
+        logging.info(
+            f"Fetched direction index for {
+                len(index)} (route, co) pairs")
+    except Exception as e:
+        logging.warning(
+            f"routeFareList fetch failed; O/I falls back to ROUTE_SEQ: {e}")
+    return index
 
 
-def assign_directions(features, route_directions):
+def _resolve_bound(properties, gtfs_stops, direction_index):
+    """(bound, distance_m) for one feature by nearest start stop, or (None, None)."""
+    coord = gtfs_stops.get(str(properties.get("ST_STOP_ID")))
+    if not coord:
+        return None, None
+    route_id = str(properties.get("ROUTE_ID"))
+    cos = [_CO_ALIAS.get(p, p.lower())
+           for p in str(properties.get("COMPANY_CODE", "")).split("+")]
+    best = None
+    for co in cos:
+        for bound, lat, lng in direction_index.get((route_id, co), []):
+            d = _haversine(coord[0], coord[1], lat, lng)
+            if best is None or d < best[1]:
+                best = (bound, d)
+    if best is None or best[1] > _MAX_MATCH_M:
+        return None, None
+    return best
+
+
+def assign_directions(features, gtfs_stops, direction_index):
     """Assign O/I to every feature of one route, together.
 
-    Resolving a route's features jointly guarantees a two-direction route gets
-    exactly one O and one I (no file overwrites another), placed in whichever
-    orientation best matches the operators' origin/destination. Falls back to
-    ROUTE_SEQ when routeFareList has no usable entry or can't disambiguate.
+    Uses the ID+coordinate resolution above; assigns a route's features jointly so
+    a two-direction route always gets exactly one O and one I (never overwriting a
+    direction's file). Falls back to ROUTE_SEQ for anything it can't resolve.
     """
-    def seq_label(f):
-        return "O" if f["properties"].get("ROUTE_SEQ", 1) == 1 else "I"
+    def seq_label(feature):
+        return "O" if feature["properties"].get("ROUTE_SEQ", 1) == 1 else "I"
 
-    if not features:
-        return []
-    p0 = features[0]["properties"]
-    co = _CO_ALIAS.get(
-        p0.get(
-            "COMPANY_CODE", ""), p0.get(
-            "COMPANY_CODE", "").lower())
-    d = route_directions.get((co, p0.get("ROUTE_NAMEE", "")))
-    if not d:
-        return [seq_label(f) for f in features]
-    o_orig, o_dest = d.get("O", (None, None))
-    i_orig, i_dest = d.get("I", (None, None))
+    def opposite(bound):
+        return "I" if bound == "O" else "O"
 
-    if len(features) == 1:
-        so = _score(features[0]["properties"], o_orig, o_dest)
-        si = _score(features[0]["properties"], i_orig, i_dest)
-        return [
-            seq_label(
-                features[0])] if so == si else (
-            ["O"] if so > si else ["I"])
+    res = [_resolve_bound(f["properties"], gtfs_stops, direction_index)
+           for f in features]
 
     if len(features) == 2:
-        a, b = (f["properties"] for f in features)
-        keep = _score(a, o_orig, o_dest) + _score(b, i_orig, i_dest)
-        swap = _score(a, i_orig, i_dest) + _score(b, o_orig, o_dest)
-        if keep != swap:
-            return ["O", "I"] if keep > swap else ["I", "O"]
+        (ba, da), (bb, db) = res
+        if ba and bb:
+            if ba != bb:
+                return [ba, bb]
+            # both nearest the same terminal: trust the closer, complement the
+            # other
+            return [ba, opposite(ba)] if da <= db else [opposite(bb), bb]
+        if ba:
+            return [ba, opposite(ba)]
+        if bb:
+            return [opposite(bb), bb]
         first = seq_label(features[0])
-        return [first, "I" if first == "O" else "O"]
+        return [first, opposite(first)]
 
-    return [seq_label(f) for f in features]
+    if len(features) == 1:
+        return [res[0][0] or seq_label(features[0])]
+
+    return [(r[0] or seq_label(f)) for r, f in zip(res, features)]
 
 
 os.makedirs("waypoints", exist_ok=True)
-route_directions = fetch_route_directions()
+gtfs_stops = fetch_gtfs_stops()
+direction_index = fetch_direction_index()
 
 for csdi_dataset in [
     # 巴士路線
@@ -190,7 +211,8 @@ for csdi_dataset in [
             feature["properties"]["ROUTE_ID"], []).append(feature)
 
     for route_id, route_features in features_by_route.items():
-        directions = assign_directions(route_features, route_directions)
+        directions = assign_directions(
+            route_features, gtfs_stops, direction_index)
         for feature, direction in zip(route_features, directions):
             with open("waypoints/" + str(route_id) + "-" + direction + ".json", "w", encoding='utf-8') as f:
                 f.write(

--- a/waypoints.py
+++ b/waypoints.py
@@ -4,11 +4,10 @@ import requests
 import json
 import re
 import os
-import csv
-import math
 import zipfile
 import io
 import glob
+import math
 import shutil
 import geopandas
 from collections import defaultdict
@@ -32,19 +31,11 @@ def store_version(key: str, version: str):
         json.dump(version_dict, f, indent=4)
 
 
-# --- Outbound (O) / inbound (I) direction resolution --------------------
-# CSDI writes ROUTE_SEQ (1/2), which does NOT track the operators' outbound/inbound
-# convention, so labelling by ROUTE_SEQ swaps some routes' -O/-I files (issue #14).
-# Resolve direction by IDs instead of terminal names (names vary too much between
-# datasets to match reliably):
-#   * CSDI ST_STOP_ID == GTFS stop_id (same registry) -> the feature's start coord
-#   * hkbus routeFareList gtfsId == CSDI ROUTE_ID (same registry) -> that route's
-#     directions, each with its bound (O/I) and first stop
-# GTFS stop-ids and hkbus's operator stop-ids are different registries with no shared
-# key, so the O-vs-I pick is by nearest start-stop *coordinate* (metres,
-# not names).
-
-GTFS_STOPS_URL = "https://static.data.gov.hk/td/pt-headway-en/gtfs.zip"
+# O/I direction (issue #14): ROUTE_SEQ doesn't track the operators' outbound/
+# inbound, so labelling by it swaps some routes. Resolve by ID instead: hkbus's
+# routeFareList gtfsId == CSDI ROUTE_ID gives each direction's bound + first stop;
+# the feature whose line starts nearest a direction's first stop takes
+# that bound.
 ROUTE_FARE_LIST_URL = "https://data.hkbus.app/routeFareList.json"
 _CO_ALIAS = {
     "LWB": "kmb",
@@ -52,122 +43,74 @@ _CO_ALIAS = {
     "CTB": "ctb",
     "NLB": "nlb",
     "GMB": "gmb"}
-_MAX_MATCH_M = 500  # a start stop farther than this is treated as unresolved
+_MAX_MATCH_M = 500
 
 
 def _haversine(lat1, lon1, lat2, lon2):
     p1, p2 = math.radians(lat1), math.radians(lat2)
-    dphi, dlmb = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
-    a = math.sin(dphi / 2) ** 2 + \
-        math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+    a = math.sin(math.radians(lat2 - lat1) / 2) ** 2 + math.cos(p1) * \
+        math.cos(p2) * math.sin(math.radians(lon2 - lon1) / 2) ** 2
     return 2 * 6371000 * math.asin(math.sqrt(a))
 
 
-def fetch_gtfs_stops():
-    """GTFS stop_id -> (lat, lon). CSDI ST_STOP_ID values are GTFS stop_ids."""
-    stops = {}
-    try:
-        z = zipfile.ZipFile(io.BytesIO(
-            requests.get(GTFS_STOPS_URL, timeout=120).content))
-        with z.open("stops.txt") as f:
-            for row in csv.DictReader(io.TextIOWrapper(f, "utf-8-sig")):
-                stops[row["stop_id"]] = (
-                    float(row["stop_lat"]), float(row["stop_lon"]))
-        logging.info(f"Fetched {len(stops)} GTFS stops")
-    except Exception as e:
-        logging.warning(
-            f"GTFS stops fetch failed; O/I falls back to ROUTE_SEQ: {e}")
-    return stops
-
-
 def fetch_direction_index():
-    """(ROUTE_ID, co) -> [(bound, lat, lng)] of each direction's first stop."""
+    """(ROUTE_ID, co) -> [(bound, lat, lng)] first stop of each O/I direction."""
     index = defaultdict(list)
     try:
         rfl = requests.get(ROUTE_FARE_LIST_URL, timeout=120).json()
-        stop_list = rfl["stopList"]
+        stops = rfl["stopList"]
         for v in rfl["routeList"].values():
-            gtfs_id = v.get("gtfsId")
-            if not gtfs_id:
-                continue
             for co in v.get("co", []):
                 bound = v.get("bound", {}).get(co)
-                stops_co = v.get("stops", {}).get(co)
-                loc = stop_list.get(stops_co[0], {}).get(
-                    "location") if stops_co else None
-                # only plain O/I; skip circular "OI"/"IO", tram "DT"/"UT",
-                # cross-boundary "LMC-*"/"TKS-*" -> those fall back to
-                # ROUTE_SEQ
-                if bound in ("O", "I") and loc:
-                    index[(gtfs_id, co)].append(
+                seq = v.get("stops", {}).get(co)
+                loc = stops.get(seq[0], {}).get("location") if seq else None
+                if bound in ("O", "I") and v.get("gtfsId") and loc:
+                    index[(v["gtfsId"], co)].append(
                         (bound, loc["lat"], loc["lng"]))
-        logging.info(
-            f"Fetched direction index for {
-                len(index)}(route, co) pairs")
     except Exception as e:
-        logging.warning(
-            f"routeFareList fetch failed; O/I falls back to ROUTE_SEQ: {e}")
+        logging.warning(f"routeFareList fetch failed; O/I via ROUTE_SEQ: {e}")
     return index
 
 
-def _resolve_bound(properties, gtfs_stops, direction_index):
-    """(bound, distance_m) for one feature by nearest start stop, or (None, None)."""
-    coord = gtfs_stops.get(str(properties.get("ST_STOP_ID")))
-    if not coord:
-        return None, None
-    route_id = str(properties.get("ROUTE_ID"))
-    cos = [_CO_ALIAS.get(p, p.lower())
-           for p in str(properties.get("COMPANY_CODE", "")).split("+")]
+def _resolve(feature, direction_index):
+    """O/I for one feature by the direction whose first stop is nearest its line
+    start, or None if unavailable / farther than the guard distance."""
+    coords = feature["geometry"]["coordinates"]
+    while isinstance(coords[0][0], list):  # MultiLineString -> first line
+        coords = coords[0]
+    lon, lat = coords[0]
+    p = feature["properties"]
+    cos = [_CO_ALIAS.get(c, c.lower())
+           for c in str(p.get("COMPANY_CODE", "")).split("+")]
     best = None
     for co in cos:
-        for bound, lat, lng in direction_index.get((route_id, co), []):
-            d = _haversine(coord[0], coord[1], lat, lng)
+        for bound, blat, blng in direction_index.get(
+                (str(p["ROUTE_ID"]), co), []):
+            d = _haversine(lat, lon, blat, blng)
             if best is None or d < best[1]:
                 best = (bound, d)
-    if best is None or best[1] > _MAX_MATCH_M:
-        return None, None
-    return best
+    return best[0] if best and best[1] <= _MAX_MATCH_M else None
 
 
-def assign_directions(features, gtfs_stops, direction_index):
-    """Assign O/I to every feature of one route, together.
-
-    Uses the ID+coordinate resolution above; assigns a route's features jointly so
-    a two-direction route always gets exactly one O and one I (never overwriting a
-    direction's file). Falls back to ROUTE_SEQ for anything it can't resolve.
-    """
-    def seq_label(feature):
-        return "O" if feature["properties"].get("ROUTE_SEQ", 1) == 1 else "I"
-
-    def opposite(bound):
-        return "I" if bound == "O" else "O"
-
-    res = [_resolve_bound(f["properties"], gtfs_stops, direction_index)
-           for f in features]
-
+def assign_directions(features, direction_index):
+    """Label a route's features jointly so it always emits one O and one I;
+    fall back to ROUTE_SEQ when a direction can't be resolved."""
+    opp = {"O": "I", "I": "O"}
+    def seq(f): return "O" if f["properties"].get("ROUTE_SEQ", 1) == 1 else "I"
+    r = [_resolve(f, direction_index) for f in features]
     if len(features) == 2:
-        (ba, da), (bb, db) = res
-        if ba and bb:
-            if ba != bb:
-                return [ba, bb]
-            # both nearest the same terminal: trust the closer, complement the
-            # other
-            return [ba, opposite(ba)] if da <= db else [opposite(bb), bb]
-        if ba:
-            return [ba, opposite(ba)]
-        if bb:
-            return [opposite(bb), bb]
-        first = seq_label(features[0])
-        return [first, opposite(first)]
-
-    if len(features) == 1:
-        return [res[0][0] or seq_label(features[0])]
-
-    return [(r[0] or seq_label(f)) for r, f in zip(res, features)]
+        a, b = r
+        if a and b and a != b:
+            return [a, b]
+        if a and not b:
+            return [a, opp[a]]
+        if b and not a:
+            return [opp[b], b]
+        return [seq(features[0]), opp[seq(features[0])]]
+    return [(x or seq(f)) for x, f in zip(r, features)]
 
 
 os.makedirs("waypoints", exist_ok=True)
-gtfs_stops = fetch_gtfs_stops()
 direction_index = fetch_direction_index()
 
 for csdi_dataset in [
@@ -208,15 +151,14 @@ for csdi_dataset in [
         data = gdf.to_geo_dict(drop_id=True)
 
     logging.info("Storing data")
-    features_by_route = {}
+    by_route = defaultdict(list)
     for feature in data["features"]:
-        features_by_route.setdefault(
-            feature["properties"]["ROUTE_ID"], []).append(feature)
+        by_route[feature["properties"]["ROUTE_ID"]].append(feature)
 
-    for route_id, route_features in features_by_route.items():
-        directions = assign_directions(
-            route_features, gtfs_stops, direction_index)
-        for feature, direction in zip(route_features, directions):
+    for route_id, feats in by_route.items():
+        for feature, direction in zip(
+            feats, assign_directions(
+                feats, direction_index)):
             with open("waypoints/" + str(route_id) + "-" + direction + ".json", "w", encoding='utf-8') as f:
                 f.write(
                     re.sub(


### PR DESCRIPTION
Fixes #14 (swapped outbound/inbound waypoints).

## What

Direction is currently written from CSDI `ROUTE_SEQ` (`"O" if ROUTE_SEQ == 1 else "I"`), which doesn't track the operators' real outbound/inbound — so some routes' `-O`/`-I` files are swapped (E32A, CTB route 10, …).

This resolves direction by **ID, not terminal names**:
- hkbus `routeFareList` `gtfsId` **==** CSDI `ROUTE_ID` → that route's directions, each with its `bound` (O/I) and first stop.
- Each CSDI feature is matched to the direction whose **first stop is nearest the feature's own line-start coordinate** (the two termini are far apart in metres, so this is near-unambiguous). Only plain `O`/`I` bounds are used; circular `OI`/`IO`, tram `DT`/`UT`, cross-boundary etc. fall back to `ROUTE_SEQ` (unchanged behaviour).
- A route's features are labelled **jointly** (always one `-O` + one `-I`), with a 500 m guard and `ROUTE_SEQ` fallback for anything unresolved.

Self-contained: one extra fetch (`routeFareList.json`), no GTFS download, ~90 lines.

## Verified (full crawl on this branch, vs prod)

- File/route count identical to prod: **3411 / 2314**; **0 malformed, 0 dropped, 0 collisions**; **139 O→I corrections**.
- Content spot-checks: `1000296-O` starts Kennedy Town, `-I` North Point; E32A `-O` starts Kwai Fong.

## Known shortcomings (documented up front)

1. **Geometry offset**: the line-start coordinate sits 7–130 m from the actual first stop. A label-by-label oracle run over all 1,537 bus routes against an exact-stop-ID variant shows the two agree on **1,532** and differ on **5** — on **118 / N118** the exact method is clearly right (i.e. this PR likely mislabels those two), the other 3 are genuinely ambiguous (both directions share a terminal, decided by metres).
2. **Direction authority is hkbus's own `routeFareList`** — if its `bound` for a route is ever wrong, this follows it.
3. **Out of scope**: the separate matching bug where synthetic circular pseudo-routes orphan ~55 real one-way entries across ~44 CTB routes (the 北角碼頭/電照街 case discussed in the group) lives in hk-bus-crawling's matcher, not here — neither this PR nor the exact variant touches it.

## Upgrade path if this isn't exact enough

An **exact ST_STOP_ID → GTFS stop_id** variant of the same fix exists at evnchn/route-waypoints PR 5 (+13.7 MB `stops.txt` fetch, ~159 lines, fixes 118/N118, same prod-parity verification). Happy to swap this PR to that approach if you prefer exactness over the lighter fetch — the two share the direction authority and joint-labelling logic, so it's a contained switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by evnchn
